### PR TITLE
Add ranking utility and tests

### DIFF
--- a/data/repos.json
+++ b/data/repos.json
@@ -1,0 +1,50 @@
+[
+  {
+    "name": "repo1",
+    "stars": 100,
+    "recency_factor": 80,
+    "issue_health": 70,
+    "doc_completeness": 90,
+    "license_freedom": 100,
+    "ecosystem_integration": 60,
+    "description": "A multi-agent coordination framework",
+    "topics": [
+      "agents",
+      "multi-agent"
+    ],
+    "score": 55.33,
+    "category": "Multi-Agent Coordination"
+  },
+  {
+    "name": "repo2",
+    "stars": 500,
+    "recency_factor": 90,
+    "issue_health": 60,
+    "doc_completeness": 80,
+    "license_freedom": 80,
+    "ecosystem_integration": 70,
+    "description": "RAG pipeline for LLMs",
+    "topics": [
+      "rag",
+      "pipeline"
+    ],
+    "score": 53.64,
+    "category": "RAG-centric"
+  },
+  {
+    "name": "repo3",
+    "stars": 50,
+    "recency_factor": 60,
+    "issue_health": 80,
+    "doc_completeness": 70,
+    "license_freedom": 90,
+    "ecosystem_integration": 50,
+    "description": "experimental tool for developers",
+    "topics": [
+      "devtool",
+      "experiment"
+    ],
+    "score": 47.99,
+    "category": "DevTools"
+  }
+]

--- a/data/top50.md
+++ b/data/top50.md
@@ -1,0 +1,5 @@
+| Rank | Repo | Score | Category |
+|------|------|-------|----------|
+| 1 | repo1 | 55.33 | Multi-Agent Coordination |
+| 2 | repo2 | 53.64 | RAG-centric |
+| 3 | repo3 | 47.99 | DevTools |

--- a/scripts/rank.py
+++ b/scripts/rank.py
@@ -1,0 +1,58 @@
+import json
+import math
+import sys
+from pathlib import Path
+
+def compute_score(repo):
+    stars = repo.get("stars", 0)
+    recency = repo.get("recency_factor", 0)
+    issue = repo.get("issue_health", 0)
+    doc = repo.get("doc_completeness", 0)
+    license_free = repo.get("license_freedom", 0)
+    ecosys = repo.get("ecosystem_integration", 0)
+    score = (
+        0.35 * math.log2(stars + 1)
+        + 0.20 * recency
+        + 0.15 * issue
+        + 0.15 * doc
+        + 0.10 * license_free
+        + 0.05 * ecosys
+    )
+    return round(score, 2)
+
+def infer_category(repo):
+    text = " ".join(repo.get("topics", [])) + " " + repo.get("description", "") + " " + repo.get("name", "")
+    text = text.lower()
+    if "rag" in text:
+        return "RAG-centric"
+    if "multi-agent" in text or "multi agent" in text or "crew" in text:
+        return "Multi-Agent Coordination"
+    if "devtool" in text or "runtime" in text or "tool" in text:
+        return "DevTools"
+    if "experiment" in text or "research" in text:
+        return "Experimental"
+    return "General-purpose"
+
+def main(json_path: str):
+    data_file = Path(json_path)
+    repos = json.loads(data_file.read_text())
+    for repo in repos:
+        repo["score"] = compute_score(repo)
+        repo["category"] = infer_category(repo)
+    repos.sort(key=lambda r: r["score"], reverse=True)
+    data_file.write_text(json.dumps(repos, indent=2))
+
+    table_lines = [
+        "| Rank | Repo | Score | Category |",
+        "|------|------|-------|----------|",
+    ]
+    for i, repo in enumerate(repos[:50], start=1):
+        table_lines.append(
+            f"| {i} | {repo.get('name')} | {repo['score']} | {repo['category']} |"
+        )
+    Path("data").mkdir(exist_ok=True)
+    Path("data/top50.md").write_text("\n".join(table_lines) + "\n")
+
+if __name__ == "__main__":
+    path = sys.argv[1] if len(sys.argv) > 1 else "data/repos.json"
+    main(path)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,37 @@
+import hashlib
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+REPO_JSON = Path('data/repos.json')
+RANK_SCRIPT = Path('scripts/rank.py')
+TOP_MD = Path('data/top50.md')
+
+def run_script():
+    subprocess.run(['python3', str(RANK_SCRIPT), str(REPO_JSON)], check=True)
+
+def load_scores():
+    data = json.loads(REPO_JSON.read_text())
+    return [item['score'] for item in data]
+
+def test_score_count_matches_repos():
+    run_script()
+    data = json.loads(REPO_JSON.read_text())
+    scores = load_scores()
+    assert len(scores) == len(data)
+
+def test_table_sorted():
+    run_script()
+    # read markdown
+    lines = [l for l in TOP_MD.read_text().splitlines() if l.startswith('|')][2:]
+    scores = [float(line.split('|')[3].strip()) for line in lines]
+    assert all(scores[i] >= scores[i+1] for i in range(len(scores)-1))
+
+def test_deterministic_output(tmp_path):
+    run_script()
+    first = hashlib.sha256(TOP_MD.read_bytes()).hexdigest()
+    run_script()
+    second = hashlib.sha256(TOP_MD.read_bytes()).hexdigest()
+    assert first == second


### PR DESCRIPTION
## Summary
- add sample `data/repos.json`
- implement scoring and category inference in `scripts/rank.py`
- generate markdown table in `data/top50.md`
- add tests validating scores and deterministic output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684be61045f4832aa8c62692a15060bd