### PR TITLE
Add static web viewer with repo filters

### DIFF
--- a/.github/workflows/deploy_site.yml
+++ b/.github/workflows/deploy_site.yml
@@ -1,0 +1,24 @@
+name: Deploy Web
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install
+        run: npm ci --prefix web
+      - name: Build
+        run: npm run build --prefix web
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: web/dist

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,2 @@
+dist/
+node_modules/

--- a/web/data/repos.json
+++ b/web/data/repos.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "CrewAI",
+    "url": "https://github.com/crewAIInc/crewAI",
+    "stars": 5000,
+    "category": "Multi-Agent Coordination",
+    "updated_at": "2025-06-12"
+  },
+  {
+    "name": "AutoGen",
+    "url": "https://github.com/microsoft/autogen",
+    "stars": 16000,
+    "category": "General-purpose",
+    "updated_at": "2025-06-10"
+  },
+  {
+    "name": "BabyAGI",
+    "url": "https://github.com/yoheinakajima/babyagi",
+    "stars": 17000,
+    "category": "Experimental",
+    "updated_at": "2025-05-15"
+  },
+  {
+    "name": "VoltAgent",
+    "url": "https://github.com/VoltAgent/voltagent",
+    "stars": 2100,
+    "category": "DevTools",
+    "updated_at": "2025-06-11"
+  }
+]

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>AgentOps Repo Index</title>
+  <style>
+    body { font-family: sans-serif; padding: 1rem; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 0.5rem; }
+    #filters { margin-bottom: 1rem; display: flex; gap: 1rem; align-items: center; }
+  </style>
+</head>
+<body>
+  <h1>AgentOps Repository Index</h1>
+  <div id="filters">
+    <label>Stars: <input type="range" id="starsRange" min="0" max="20000" step="100" value="0"></label>
+    <span id="starsValue">0+</span>
+    <label>Category:
+      <select id="categorySelect"></select>
+    </label>
+    <label><input type="checkbox" id="recentToggle"> Updated &lt;30d</label>
+  </div>
+  <table id="repoTable">
+    <thead>
+      <tr><th>Name</th><th>Stars</th><th>Category</th><th>Updated</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+<script>
+async function load() {
+  const res = await fetch('data/repos.json');
+  const data = await res.json();
+  const tbody = document.querySelector('#repoTable tbody');
+  const catSel = document.getElementById('categorySelect');
+  const range = document.getElementById('starsRange');
+  const rangeVal = document.getElementById('starsValue');
+  const toggle = document.getElementById('recentToggle');
+
+  const categories = Array.from(new Set(data.map(r => r.category)));
+  catSel.innerHTML = '<option value="">All</option>' + categories.map(c => `<option>${c}</option>`).join('');
+
+  function render() {
+    const minStars = parseInt(range.value);
+    rangeVal.textContent = minStars + '+';
+    const cat = catSel.value;
+    const now = Date.now();
+    const rows = data.filter(r => {
+      if (r.stars < minStars) return false;
+      if (cat && r.category !== cat) return false;
+      if (toggle.checked) {
+        const diff = (now - new Date(r.updated_at)) / (1000*60*60*24);
+        if (diff > 30) return false;
+      }
+      return true;
+    }).map(r => `<tr><td><a href="${r.url}">${r.name}</a></td><td>${r.stars}</td><td>${r.category}</td><td>${r.updated_at}</td></tr>`).join('');
+    tbody.innerHTML = rows;
+  }
+
+  range.oninput = render;
+  catSel.onchange = render;
+  toggle.onchange = render;
+  render();
+}
+load();
+</script>
+</body>
+</html>

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "agentops-web",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "agentops-web",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "agentops-web",
+  "version": "1.0.0",
+  "scripts": {
+    "build": "rm -rf dist && mkdir -p dist/data && cp index.html dist/index.html && cp data/repos.json dist/data/repos.json"
+  }
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy static web site
- create simple `web` directory with repo table and filters
- include sample repository data
- provide npm build script to assemble `dist`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build --prefix web`

------
https://chatgpt.com/codex/tasks/task_e_684be677f968832aac5dd9b6dab9727b