### PR TITLE
Add coverage checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: pytest --cov=scripts --cov-report=xml
+        env:
+          PYTHONHASHSEED: 0
+      - name: Check coverage
+        run: |
+          python - <<'PY'
+          import xml.etree.ElementTree as ET, sys
+          cov = int(float(ET.parse('coverage.xml').getroot().attrib['line-rate']) * 100)
+          sys.exit(0 if cov >= 90 else 1)
+          PY
+        env:
+          PYTHONHASHSEED: 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pytest
+pytest-cov

--- a/scripts/helpers.py
+++ b/scripts/helpers.py
@@ -1,0 +1,5 @@
+"""Helper functions for AgentOps."""
+
+def add(a: int, b: int) -> int:
+    """Return the sum of a and b."""
+    return a + b

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+# ensure project root is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from scripts import helpers
+
+
+def test_add():
+    assert helpers.add(2, 3) == 5


### PR DESCRIPTION
## Summary
- add helper script with tests
- record requirements including pytest-cov
- run coverage in CI and fail if below 90%

## Testing
- `pytest --cov=scripts --cov-report=xml`
- `python - <<'PY'
import xml.etree.ElementTree as ET, sys
cov = int(float(ET.parse('coverage.xml').getroot().attrib['line-rate']) * 100)
print(cov)
PY`


------
https://chatgpt.com/codex/tasks/task_e_684be6d5d7d4832a80f388bdd0a31823