### PR TITLE
Add VS Code devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.11-slim
+
+# Install git and curl
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js (18.x)
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python tooling
+RUN pip install --no-cache-dir pre-commit black ruff
+
+WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "name": "AgentOps Dev Container",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "postCreateCommand": "pre-commit install",
+    "customizations": {
+        "vscode": {
+            "workspaceCommands": [
+                { "name": "Run Tests", "command": "pytest -q" },
+                { "name": "Run Scrape", "command": "python scripts/scrape.py" }
+            ]
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- set up `.devcontainer` folder
- add Dockerfile using python:3.11-slim with git, node, pre-commit, black and ruff
- configure `devcontainer.json` to auto-run `pre-commit install`
- expose workspace commands for running tests and scraping

## Testing
- `pytest -q`
- `devcontainer build --workspace-folder .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bed25d7c0832a970085a9cfc909b2