### PR TITLE
Add pa11y setup script and README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,31 @@ python3 scripts/agentops.py --min-stars 50 --iterations 1 --output data
 
 Generated tables live in the `data/` directory.
 
+## 🧪 Testing
+
+This project uses `pytest` for unit tests and [pa11y](https://github.com/pa11y/pa11y) for accessibility checks. Ensure Chrome is installed before running pa11y:
+
+```bash
+# via puppeteer
+npx puppeteer browsers install chrome
+# or with apt
+sudo apt-get install -y chromium
+```
+
+Run tests with:
+
+```bash
+pytest -q
+```
+
+To check accessibility after building the site:
+
+```bash
+npx pa11y web/index.html
+```
+
+You can also run `./scripts/install_pa11y_deps.sh` to install pa11y and Chrome.
+
 -----
 
 ## 🤝 How to Contribute

--- a/scripts/install_pa11y_deps.sh
+++ b/scripts/install_pa11y_deps.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# Install dependencies for pa11y and ensure Chrome is available
+set -e
+
+# Install pa11y globally
+npm install -g pa11y
+
+# Install Chrome for puppeteer
+npx puppeteer browsers install chrome


### PR DESCRIPTION
## Summary
- describe how to run tests and pa11y
- add a helper script to install pa11y and Chrome

## Testing
- `pytest -q` *(fails: Command '['git', 'diff', '--exit-code']' returned non-zero exit status 1)*

------
https://chatgpt.com/codex/tasks/task_e_684c011c158c832a83dcafc4117769ed