### PR TITLE
Resolve merge artefacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ The definitive list of Agentic-AI repositories, ranked by the AgentOps Score. Th
 | 41 | PraisonAI | 0.0 | Multi-Agent Coordination |
 | 42 | AutoAgent | 0.0 | General-purpose |
 | 43 | AgentVerse | 0.0 | General-purpose |
-| 44 | agentops | 0.0 | Multi-Agent Coordination |
+| 44 | [agentops](https://github.com/AgentOps-AI/agentops) | 0.0 | Multi-Agent Coordination |
 | 45 | 12-factor-agents | 0.0 | General-purpose |
 | 46 | cognita | 0.0 | RAG-centric |
 | 47 | spring-ai-alibaba | 0.0 | General-purpose |

--- a/data/top50.md
+++ b/data/top50.md
@@ -43,7 +43,7 @@
 | 41 | PraisonAI | 0.0 | Multi-Agent Coordination |
 | 42 | AutoAgent | 0.0 | General-purpose |
 | 43 | AgentVerse | 0.0 | General-purpose |
-| 44 | agentops | 0.0 | Multi-Agent Coordination |
+| 44 | [agentops](https://github.com/AgentOps-AI/agentops) | 0.0 | Multi-Agent Coordination |
 | 45 | 12-factor-agents | 0.0 | General-purpose |
 | 46 | cognita | 0.0 | RAG-centric |
 | 47 | spring-ai-alibaba | 0.0 | General-purpose |


### PR DESCRIPTION
## Summary
- fix data table link for agentops repo
- update README table via injection

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_684c0dab5264832a9c8cbea44703ea24